### PR TITLE
Code liniting

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -88,7 +88,8 @@ if (WEBPACK_CUSTOM_ADD_PATH_CONFIG) {
   customConfig = require(WEBPACK_CUSTOM_ADD_PATH)
 }
 
-const myConfig = merge({
+const myConfig = merge(
+  {
     // webpack cache system
     cache: {
       type: 'filesystem'
@@ -105,108 +106,108 @@ const myConfig = merge({
     },
     module: {
       rules: [
-      {
-        test: /\.jsx?$/,
-        // exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              '@babel/preset-env',
-              '@babel/react',
-              {
-                plugins: [
-                  '@babel/plugin-proposal-class-properties'
-                ]
-              }
-            ], // Preset used for env setup
-            plugins: [
-              ['@babel/transform-react-jsx']
-            ],
-            cacheDirectory: true,
-            cacheCompression: true
-          }
-        }
-      },
-      {
-        test: /\.s?css$/,
-        use: [{
-          loader: MiniCssExtractPlugin.loader
-        },
         {
-          loader: 'css-loader',
-          options: {
-            sourceMap: false
-          }
-        },
-        {
-          loader: 'resolve-url-loader'
-        },
-        {
-          loader: 'postcss-loader',
-          options: {
-            sourceMap: true,
-            postcssOptions: {
-              plugins: ['autoprefixer']
+          test: /\.jsx?$/,
+          // exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                '@babel/preset-env',
+                '@babel/react',
+                {
+                  plugins: [
+                    '@babel/plugin-proposal-class-properties'
+                  ]
+                }
+              ], // Preset used for env setup
+              plugins: [
+                ['@babel/transform-react-jsx']
+              ],
+              cacheDirectory: true,
+              cacheCompression: true
             }
           }
         },
         {
-          loader: 'sass-loader',
-          options: {
-            sourceMap: true
-          }
-        }]
-      },
-      {
-        test: /\.(png|webp|jpg|jpeg|gif|svg)$/,
-        use: [{
-          loader: 'img-optimize-loader',
-          options: {
-            name: '[name].[ext]',
-            outputPath: IMG_DIR_CONFIG,
-            compress: {
+          test: /\.s?css$/,
+          use: [{
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: false
+            }
+          },
+          {
+            loader: 'resolve-url-loader'
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+              postcssOptions: {
+                plugins: ['autoprefixer']
+              }
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }]
+        },
+        {
+          test: /\.(png|webp|jpg|jpeg|gif|svg)$/,
+          use: [{
+            loader: 'img-optimize-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: IMG_DIR_CONFIG,
+              compress: {
               // This will take more time and get smaller images.
-              mode: 'low', // 'lossless', 'high', 'low'
-              disableOnDevelopment: true,
-              // convert to webp
-              webp: false,
-              // loseless compression for png
-              optipng: {
-                optimizationLevel: 4
+                mode: 'low', // 'lossless', 'high', 'low'
+                disableOnDevelopment: true,
+                // convert to webp
+                webp: false,
+                // loseless compression for png
+                optipng: {
+                  optimizationLevel: 4
+                },
+                // lossy compression for png. This will generate smaller file than optipng.
+                pngquant: {
+                  quality: [0.2, 0.8]
+                },
+                // Compression for svg.
+                svgo: true,
+                // Compression for gif.
+                gifsicle: {
+                  optimizationLevel: 3
+                },
+                // Compression for jpg.
+                mozjpeg: {
+                  progressive: true,
+                  quality: 60
+                }
               },
-              // lossy compression for png. This will generate smaller file than optipng.
-              pngquant: {
-                quality: [0.2, 0.8]
-              },
-              // Compression for svg.
-              svgo: true,
-              // Compression for gif.
-              gifsicle: {
-                optimizationLevel: 3
-              },
-              // Compression for jpg.
-              mozjpeg: {
-                progressive: true,
-                quality: 60
+              inline: {
+                limit: 1
               }
-            },
-            inline: {
-              limit: 1
             }
-          }
+          }]
+        },
+        {
+          test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
+          use: [{
+            loader: 'file-loader',
+            options: {
+              outputPath: FONTS_DIR_CONFIG,
+              name: '[name].[ext]'
+            }
+          }]
         }]
-      },
-      {
-        test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
-        use: [{
-          loader: 'file-loader',
-          options: {
-            outputPath: FONTS_DIR_CONFIG,
-            name: '[name].[ext]'
-          }
-        }]
-      }]
     },
 
     // extra settings

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -244,10 +244,10 @@ const myConfig = merge({
 
     // in case you load it from CDN
     /* externals: {
-                      jquery: 'jQuery',
-                      react: 'React',
-                      'react-dom': 'ReactDOM',
-                  }, */
+                        jquery: 'jQuery',
+                        react: 'React',
+                        'react-dom': 'ReactDOM',
+                    }, */
   },
   customConfig
 )

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,7 @@
 const path = require('path')
-const { merge } = require('webpack-merge')
+const {
+  merge
+} = require('webpack-merge')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
@@ -87,22 +89,22 @@ if (WEBPACK_CUSTOM_ADD_PATH_CONFIG) {
 }
 
 const myConfig = merge({
-  // webpack cache system
-  cache: {
-    type: 'filesystem'
-  },
-  entry: {
-    app: [
-      JS_FILE,
-      CSS_FILE
-    ]
-  },
-  output: {
-    filename: '[name].js',
-    path: path.resolve(DIST_DIR)
-  },
-  module: {
-    rules: [
+    // webpack cache system
+    cache: {
+      type: 'filesystem'
+    },
+    entry: {
+      app: [
+        JS_FILE,
+        CSS_FILE
+      ]
+    },
+    output: {
+      filename: '[name].js',
+      path: path.resolve(DIST_DIR)
+    },
+    module: {
+      rules: [
       {
         test: /\.jsx?$/,
         // exclude: /node_modules/,
@@ -131,31 +133,30 @@ const myConfig = merge({
         use: [{
           loader: MiniCssExtractPlugin.loader
         },
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: false
-            }
-          },
-          {
-            loader: 'resolve-url-loader'
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              sourceMap: true,
-              postcssOptions: {
-                plugins: ['autoprefixer']
-              }
-            }
-          },
-          {
-            loader: 'sass-loader',
-            options: {
-              sourceMap: true
+        {
+          loader: 'css-loader',
+          options: {
+            sourceMap: false
+          }
+        },
+        {
+          loader: 'resolve-url-loader'
+        },
+        {
+          loader: 'postcss-loader',
+          options: {
+            sourceMap: true,
+            postcssOptions: {
+              plugins: ['autoprefixer']
             }
           }
-        ]
+        },
+        {
+          loader: 'sass-loader',
+          options: {
+            sourceMap: true
+          }
+        }]
       },
       {
         test: /\.(png|webp|jpg|jpeg|gif|svg)$/,
@@ -165,26 +166,26 @@ const myConfig = merge({
             name: '[name].[ext]',
             outputPath: IMG_DIR_CONFIG,
             compress: {
-            // This will take more time and get smaller images.
+              // This will take more time and get smaller images.
               mode: 'low', // 'lossless', 'high', 'low'
               disableOnDevelopment: true,
-            // convert to webp
+              // convert to webp
               webp: false,
-            // loseless compression for png
+              // loseless compression for png
               optipng: {
                 optimizationLevel: 4
               },
-            // lossy compression for png. This will generate smaller file than optipng.
+              // lossy compression for png. This will generate smaller file than optipng.
               pngquant: {
                 quality: [0.2, 0.8]
               },
-            // Compression for svg.
+              // Compression for svg.
               svgo: true,
-            // Compression for gif.
+              // Compression for gif.
               gifsicle: {
                 optimizationLevel: 3
               },
-            // Compression for jpg.
+              // Compression for jpg.
               mozjpeg: {
                 progressive: true,
                 quality: 60
@@ -205,51 +206,50 @@ const myConfig = merge({
             name: '[name].[ext]'
           }
         }]
-      }
-    ]
-  },
-
-  // extra settings
-  resolve: {
-
-    // defines root folders for compatibility
-    roots: [
-      path.resolve('./../../'),
-      path.resolve('./../../public')
-    ],
-
-    // //node modules to include
-    modules: [
-      path.join(__dirname, 'node_modules'),
-      path.resolve(NODE_DIR)
-    ],
-
-    // aliases
-    alias: {
-      'window.jQuery': require.resolve('jquery'),
-      $: require.resolve('jquery'),
-      jQuery: require.resolve('jquery'),
-
-      // react: require.resolve('react'),
-      // 'react-dom': require.resolve('react-dom'),
-
-      site: path.resolve('./../../'),
-      PROJECT_ROOT_DIR: path.resolve('./../../')
+      }]
     },
 
-    fallback: {
-      path: false
-    }
-  }
+    // extra settings
+    resolve: {
 
-  // in case you load it from CDN
-  /* externals: {
-                  jquery: 'jQuery',
-                  react: 'React',
-                  'react-dom': 'ReactDOM',
-              }, */
-},
-customConfig
+      // defines root folders for compatibility
+      roots: [
+        path.resolve('./../../'),
+        path.resolve('./../../public')
+      ],
+
+      // //node modules to include
+      modules: [
+        path.join(__dirname, 'node_modules'),
+        path.resolve(NODE_DIR)
+      ],
+
+      // aliases
+      alias: {
+        'window.jQuery': require.resolve('jquery'),
+        $: require.resolve('jquery'),
+        jQuery: require.resolve('jquery'),
+
+        // react: require.resolve('react'),
+        // 'react-dom': require.resolve('react-dom'),
+
+        site: path.resolve('./../../'),
+        PROJECT_ROOT_DIR: path.resolve('./../../')
+      },
+
+      fallback: {
+        path: false
+      }
+    }
+
+    // in case you load it from CDN
+    /* externals: {
+                      jquery: 'jQuery',
+                      react: 'React',
+                      'react-dom': 'ReactDOM',
+                  }, */
+  },
+  customConfig
 )
 
 module.exports = myConfig

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,9 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const common = require('./webpack.common.js')
 
 /* merges shared modules */
-const { merge } = require('webpack-merge')
+const {
+  merge
+} = require('webpack-merge')
 
 const path = require('path')
 const ROOT_DIR_CONFIG = process.env.npm_config_root_dir || '../..'
@@ -83,7 +85,9 @@ const conf = merge(
             preset: [
               'default',
               {
-                discardComments: { removeAll: true },
+                discardComments: {
+                  removeAll: true
+                },
                 zindex: true,
                 cssDeclarationSorter: true,
                 reduceIdents: false,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,7 +20,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 /**
  * merge shared modules
  */
-const { merge } = require('webpack-merge')
+const {
+  merge
+} = require('webpack-merge')
 
 /**
  * shared modules between dev and production config


### PR DESCRIPTION
Used:
1) https://github.com/victorporof/Sublime-HTMLPrettify
2) standard --fix (https://standardjs.com/)
 
Config .jsbeutifyrc 
`{
    // The plugin looks for a .jsbeautifyrc file in the same directory as the
    // source file you're prettifying (or any directory above if it doesn't exist,
    // or in your home folder if everything else fails) and uses those options
    // along the default ones.

    // Details: https://github.com/victorporof/Sublime-HTMLPrettify#using-your-own-jsbeautifyrc-options
    // Documentation: https://github.com/beautify-web/js-beautify

    "all": {
        // These rules apply to any supported code that is going to be be prettified,
        // and have the lowest level of precedence (meaning any of the settings in
        // the 'html', 'css', 'js', 'json' and 'custom' categories override these).

        // You can add other .jsbeautifyrc rules in this section too.

        // End output with newline
        "end_with_newline": false,

        // Character(s) to use as line terminators.
        "eol": "\n",

        // Initial indentation level
        "indent_level": 0,

        // Indentation character
        "indent_char": " ",

        // Indentation size
        "indent_size": 2,

        // Indent with tabs, overrides `indent_size` and `indent_char`
        "indent_with_tabs": false,

        // Maximum number of line breaks to be preserved in one chunk (0 disables)
        "max_preserve_newlines": 0,

        // Whether existing line breaks before elements should be preserved (only works before elements, not inside tags or for text)
        "preserve_newlines": true,

        // Lines should wrap at next opportunity after this number of characters (0 disables)
        "wrap_line_length": 0
    },

    "html": {
        // Rules added here apply only to HTML-like files, as determined by the
        // rules specified for `global_file_rules` in the plugin settings. They
        // take precedence  over all of the settings in the 'all' category above.

        // You can add other .jsbeautifyrc rules in this section too.

        // e.g. {{#foo}}, {{/foo}}
        "indent_handlebars": false,

        // Indent <head> and <body> sections
        "indent_inner_html": false,

        // [keep|separate|normal]
        "indent_scripts": "keep",

        // List of tags that should not be reformatted.  This should generally not be needed. 
        "unformatted": [],
    },

    "css": {
        // Rules added here apply only to CSS-like files, as determined by the
        // rules specified for `global_file_rules` in the plugin settings. They
        // take precedence  over all of the settings in the 'all' category above.

        // You can add other .jsbeautifyrc rules in this section too.

        // Add a new line after every css rule
        "newline_between_rules": true,

        // Selector separator character
        "selector_separator": " ",

        // Separate selectors with newline or not (e.g. "a,\nbr" or "a, br")
        "selector_separator_newline": true
    },

    "js": {
        // Rules added here apply only to JS-like files, as determined by the
        // rules specified for `global_file_rules` in the plugin settings. They
        // take precedence  over all of the settings in the 'all' category above.

        // You can add other .jsbeautifyrc rules in this section too.

        // [collapse|collapse-preserve-inline|expand|end-expand|none] Put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or put end braces on own line, or attempt to keep them where they are
        "brace_style": "none",

        // Break chained method calls across subsequent lines
        "break_chained_methods": false,

        // Put commas at the beginning of new line instead of end
        "comma_first": false,

        // Pass E4X xml literals through untouched
        "e4x": true,

        // If true, then jslint-stricter mode is enforced
        "jslint_happy": false,

        // Preserve array indentation
        "keep_array_indentation": false,

        // Preserve function indentation
        "keep_function_indentation": false,

        // [before-newline|after-newline|preserve-newline] Set operator position
        "operator_position": "before-newline",

        // Should the space before an anonymous function's parens be added, "function()" vs "function ()"
        "space_after_anon_function": false,

        // Should the space before conditional statement be added, "if(true)" vs "if (true)"
        "space_before_conditional": true,

        // Add padding spaces within empty paren, "f()" vs "f( )"
        "space_in_empty_paren": false,

        // Add padding spaces within paren, ie. f( a, b )
        "space_in_paren": false,

        // Should printable characters in strings encoded in \xNN notation be unescaped, "example" vs "\x65\x78\x61\x6d\x70\x6c\x65"
        "unescape_strings": false
    },

    "json": {
        // Rules added here apply only to JSON-like files, as determined by the
        // rules specified for `global_file_rules` in the plugin settings. They
        // take precedence over all of the settings in the 'all' category above.

        // You can add other .jsbeautifyrc rules in this section too.

        // [collapse|collapse-preserve-inline|expand|end-expand|none] Put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or put end braces on own line, or attempt to keep them where they are
        "brace_style": "collapse-preserve-inline",

        // Preserve array indentation
        "keep_array_indentation": false,

        // Should printable characters in strings encoded in \xNN notation be unescaped, "example" vs "\x65\x78\x61\x6d\x70\x6c\x65"
        "unescape_strings": false
    },

    "custom": {
        // Rules added here apply only to files matching specific glob strings,
        // but respecting any whitelists or blacklists as determined by the
        // rules specified for `global_file_rules` in the plugin settings. They
        // take precedence over any of the settings in the categories above.

        // For the following entries, keys are globs and values are objects which
        // can contain any kind of .jsbeautifyrc setting.

        "@(package?(-lock)|yarn-lock).json": {
            "indent_size": 2,
            "brace_style": "collapse"
        },

        "*.sublime-@(settings|keymap|commands|menu)": {
            "indent_size": 4,
            "brace_style": "expand"
        }
    }
}`